### PR TITLE
Update README Next.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Aplicație de tip **eCommerce** pentru vânzarea de haine, construită cu **Next
 - **Email-sender** – (în lucru)
 
 ### 🔜 Frontend – Next.js
-- **Next.js 14** – React-based SSR framework
+- **Next.js 15** – React-based SSR framework
 - **React.js** – component-based UI
 - **Tailwind CSS** – framework de stilizare
 - **fetch() API** – pentru integrarea cu Flask backend


### PR DESCRIPTION
## Summary
- bump Next.js version from 14 to 15 in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683f5e5a350c8322af958c49cb5f5576